### PR TITLE
fix(gateway): try multiple gateways when searching

### DIFF
--- a/src/aio/async_std.rs
+++ b/src/aio/async_std.rs
@@ -41,11 +41,7 @@ pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<AsyncStd>,
     let max_search_time = options.timeout.unwrap_or(DEFAULT_TIMEOUT);
     let start_search_time = std::time::Instant::now();
 
-    loop {
-        if start_search_time.elapsed() > max_search_time {
-            break Err(SearchError::NoResponseWithinTimeout);
-        }
-
+    while start_search_time.elapsed() < max_search_time {
         let search_response = receive_search_response(&mut socket);
 
         // Receive search response
@@ -85,7 +81,7 @@ pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<AsyncStd>,
             }
         };
 
-        break Ok(Gateway {
+        return Ok(Gateway {
             addr,
             root_url,
             control_url,
@@ -94,6 +90,8 @@ pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<AsyncStd>,
             provider: AsyncStd,
         });
     }
+
+    Err(SearchError::NoResponseWithinTimeout)
 }
 
 // Create a new search.

--- a/src/aio/async_std.rs
+++ b/src/aio/async_std.rs
@@ -11,6 +11,7 @@ use log::debug;
 use super::{Provider, HEADER_NAME, MAX_RESPONSE_SIZE};
 use crate::aio::Gateway;
 use crate::common::{messages, parsing, SearchOptions};
+use crate::common::options::{DEFAULT_TIMEOUT, RESPONSE_TIMEOUT};
 use crate::errors::SearchError;
 use crate::RequestError;
 
@@ -37,27 +38,62 @@ pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<AsyncStd>,
 
     send_search_request(&mut socket, options.broadcast_address).await?;
 
-    let search_response = receive_search_response(&mut socket);
+    let max_search_time = options.timeout.unwrap_or(DEFAULT_TIMEOUT);
+    let start_search_time = std::time::Instant::now();
 
-    // Receive search response, optionally with a timeout.
-    let (response_body, from) = match options.timeout {
-        Some(t) => timeout(t, search_response).await?,
-        None => search_response.await,
-    }?;
+    loop {
+        if start_search_time.elapsed() > max_search_time {
+            break Err(SearchError::NoResponseWithinTimeout);
+        }
 
-    let (addr, root_url) = handle_broadcast_resp(&from, &response_body)?;
+        let search_response = receive_search_response(&mut socket);
 
-    let (control_schema_url, control_url) = get_control_urls(&addr, &root_url).await?;
-    let control_schema = get_control_schemas(&addr, &control_schema_url).await?;
+        // Receive search response
+        let (response_body, from) = match timeout(RESPONSE_TIMEOUT, search_response).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(err)) => {
+                debug!("error while receiving broadcast response: {err}");
+                continue;
+            },
+            Err(_) => {
+                debug!("timeout while receiving broadcast response");
+                continue;
+            }
+        };
 
-    Ok(Gateway {
-        addr,
-        root_url,
-        control_url,
-        control_schema_url,
-        control_schema,
-        provider: AsyncStd,
-    })
+        let (addr, root_url) = match handle_broadcast_resp(&from, &response_body) {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("error handling broadcast response: {}", e);
+                continue;
+            }
+        };
+
+        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url).await {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("error getting control URLs: {}", e);
+                continue;
+            }
+        };
+
+        let control_schema = match get_control_schemas(&addr, &control_schema_url).await {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("error getting control schemas: {}", e);
+                continue;
+            }
+        };
+
+        break Ok(Gateway {
+            addr,
+            root_url,
+            control_url,
+            control_schema_url,
+            control_schema,
+            provider: AsyncStd,
+        });
+    }
 }
 
 // Create a new search.

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -13,10 +13,9 @@ use hyper::{
 use tokio::{net::UdpSocket, time::timeout};
 
 use log::debug;
-use tokio::time::error::Elapsed;
 use crate::common::{messages, parsing, SearchOptions};
 use crate::{aio::Gateway, RequestError};
-use crate::common::options::DEFAULT_TIMEOUT;
+use crate::common::options::{DEFAULT_TIMEOUT, RESPONSE_TIMEOUT};
 use super::{Provider, HEADER_NAME, MAX_RESPONSE_SIZE};
 use crate::errors::SearchError;
 
@@ -43,9 +42,6 @@ impl Provider for Tokio {
         Ok(string)
     }
 }
-
-/// Timeout for each broadcast response.
-pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Search for a gateway with the provided options.
 pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<Tokio>, SearchError> {

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -1,6 +1,8 @@
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Gateway search configuration
 ///
 /// SearchOptions::default() should suffice for most situations.
@@ -30,7 +32,7 @@ impl Default for SearchOptions {
         Self {
             bind_addr: (IpAddr::from([0, 0, 0, 0]), 0).into(),
             broadcast_address: "239.255.255.250:1900".parse().unwrap(),
-            timeout: Some(Duration::from_secs(10)),
+            timeout: Some(DEFAULT_TIMEOUT),
         }
     }
 }

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -1,7 +1,10 @@
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
+/// Default timeout for a gateway search.
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Timeout for each broadcast response during a gateway search.
+pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Gateway search configuration
 ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -326,6 +326,8 @@ pub enum SearchError {
     HttpError(attohttpc::Error),
     /// Unable to process the response
     InvalidResponse,
+    /// Did not receive any valid response within timeout
+    NoResponseWithinTimeout,
     /// IO Error
     IoError(io::Error),
     /// UTF-8 decoding error
@@ -407,6 +409,7 @@ impl fmt::Display for SearchError {
         match *self {
             SearchError::HttpError(ref e) => write!(f, "HTTP error {e}"),
             SearchError::InvalidResponse => write!(f, "Invalid response"),
+            SearchError::NoResponseWithinTimeout => write!(f, "No response within timeout"),
             SearchError::IoError(ref e) => write!(f, "IO error: {e}"),
             SearchError::Utf8Error(ref e) => write!(f, "UTF-8 error: {e}"),
             SearchError::XmlError(ref e) => write!(f, "XML error: {e}"),
@@ -425,6 +428,7 @@ impl error::Error for SearchError {
         match *self {
             SearchError::HttpError(ref e) => Some(e),
             SearchError::InvalidResponse => None,
+            SearchError::NoResponseWithinTimeout => None,
             SearchError::IoError(ref e) => Some(e),
             SearchError::Utf8Error(ref e) => Some(e),
             SearchError::XmlError(ref e) => Some(e),


### PR DESCRIPTION
In the case that a network contains multiple UPnP devices that respond to the search gateway signal; Try them all until one of them is considered valid.