### PR TITLE
update to hyper 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Cargo.lock
 # misc
 **/.DS_Store
 .idea
+.helix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ all-features = true
 attohttpc = { version = "0.24", default-features = false }
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
-http = { version = "0.2", optional = true }
+http = { version = "1", optional = true }
 log = "0.4"
 rand = "0.8"
 tokio = { version = "1", optional = true, features = ["net"] }
 async-std = { version = "1", optional = true }
 surf = { version = "2.3.2", optional = true, default-features = false }
+http-body-util = { version = "0.1", optional = true }
 
 url = "2"
 xmltree = "0.10"
@@ -30,9 +31,15 @@ async-trait = { version = "0.1.72", optional = true }
 
 [dependencies.hyper]
 default-features = false
-features = ["client", "http1", "http2", "runtime"]
+features = ["client", "http1", "http2"]
 optional = true
-version = "0.14"
+version = "1"
+
+[dependencies.hyper-util]
+default-features = false
+features = ["client", "client-legacy", "http1", "http2"]
+optional = true
+version = "0.1"
 
 [dev-dependencies]
 simplelog = "0.12"
@@ -40,7 +47,7 @@ tokio = { version = "1", features = ["full"] }
 async-std = { version = "1", features = ["attributes"]}
 
 [features]
-aio_tokio = ["futures", "tokio", "hyper", "bytes", "http", "async-trait"]
+aio_tokio = ["futures", "tokio", "hyper", "hyper-util", "http-body-util", "bytes", "http", "async-trait"]
 aio_async_std = ["futures", "async-std", "surf/h1-client-rustls", "bytes", "http", "async-trait"]
 default = []
 

--- a/src/aio/async_std.rs
+++ b/src/aio/async_std.rs
@@ -10,8 +10,8 @@ use log::debug;
 
 use super::{Provider, HEADER_NAME, MAX_RESPONSE_SIZE};
 use crate::aio::Gateway;
-use crate::common::{messages, parsing, SearchOptions};
 use crate::common::options::{DEFAULT_TIMEOUT, RESPONSE_TIMEOUT};
+use crate::common::{messages, parsing, SearchOptions};
 use crate::errors::SearchError;
 use crate::RequestError;
 
@@ -50,7 +50,7 @@ pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<AsyncStd>,
             Ok(Err(err)) => {
                 debug!("error while receiving broadcast response: {err}");
                 continue;
-            },
+            }
             Err(_) => {
                 debug!("timeout while receiving broadcast response");
                 continue;

--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -118,9 +118,7 @@ impl<P: Provider> Gateway<P> {
         } else {
             // The router does not have the AddAnyPortMapping method.
             // Fall back to using AddPortMapping with a random port.
-            let gateway = self.clone();
-            gateway
-                .retry_add_random_port_mapping(protocol, local_addr, lease_duration, description)
+            self.retry_add_random_port_mapping(protocol, local_addr, lease_duration, description)
                 .await
         }
     }
@@ -153,8 +151,6 @@ impl<P: Provider> Gateway<P> {
         description: &str,
     ) -> Result<u16, AddAnyPortError> {
         let description = description.to_owned();
-        let gateway = self.clone();
-
         let external_port = common::random_port();
         let res = self
             .add_port_mapping(protocol, external_port, local_addr, lease_duration, &description)
@@ -165,8 +161,7 @@ impl<P: Provider> Gateway<P> {
             Err(err) => match parsing::convert_add_random_port_mapping_error(err) {
                 Some(err) => Err(err),
                 None => {
-                    gateway
-                        .add_same_port_mapping(protocol, local_addr, lease_duration, &description)
+                    self.add_same_port_mapping(protocol, local_addr, lease_duration, &description)
                         .await
                 }
             },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,9 @@ pub enum RequestError {
     /// When using the aio feature.
     #[cfg(feature = "aio_tokio")]
     HyperError(hyper::Error),
+    /// When using the aio feature.
+    #[cfg(feature = "aio_tokio")]
+    HyperClientError(hyper_util::client::legacy::Error),
 
     /// When using aio async std feature
     #[cfg(feature = "aio_async_std")]
@@ -95,6 +98,13 @@ impl From<Elapsed> for RequestError {
     }
 }
 
+#[cfg(feature = "aio_tokio")]
+impl From<hyper_util::client::legacy::Error> for RequestError {
+    fn from(err: hyper_util::client::legacy::Error) -> Self {
+        RequestError::HyperClientError(err)
+    }
+}
+
 impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -107,6 +117,8 @@ impl fmt::Display for RequestError {
             RequestError::SurfError(ref e) => write!(f, "Surf Error: {e}"),
             #[cfg(feature = "aio_tokio")]
             RequestError::HyperError(ref e) => write!(f, "Hyper Error: {e}"),
+            #[cfg(feature = "aio_tokio")]
+            RequestError::HyperClientError(ref e) => write!(f, "Hyper Client Error: {e}"),
             #[cfg(any(feature = "aio_tokio", feature = "aio_async_std"))]
             RequestError::HttpError(ref e) => write!(f, "Http  Error: {e}"),
             #[cfg(any(feature = "aio_tokio", feature = "aio_async_std"))]
@@ -127,6 +139,8 @@ impl std::error::Error for RequestError {
             RequestError::SurfError(ref e) => Some(e.as_ref()),
             #[cfg(feature = "aio_tokio")]
             RequestError::HyperError(ref e) => Some(e),
+            #[cfg(feature = "aio_tokio")]
+            RequestError::HyperClientError(ref e) => Some(e),
             #[cfg(any(feature = "aio_tokio", feature = "aio_async_std"))]
             RequestError::HttpError(ref e) => Some(e),
             #[cfg(any(feature = "aio_tokio", feature = "aio_async_std"))]
@@ -340,6 +354,9 @@ pub enum SearchError {
     /// When using the aio feature.
     #[cfg(feature = "aio_tokio")]
     HyperError(hyper::Error),
+    /// When using the aio feature.
+    #[cfg(feature = "aio_tokio")]
+    HyperClientError(hyper_util::client::legacy::Error),
     /// Error parsing URI
     #[cfg(feature = "aio_tokio")]
     InvalidUri(hyper::http::uri::InvalidUri),
@@ -404,6 +421,13 @@ impl From<Elapsed> for SearchError {
     }
 }
 
+#[cfg(feature = "aio_tokio")]
+impl From<hyper_util::client::legacy::Error> for SearchError {
+    fn from(err: hyper_util::client::legacy::Error) -> Self {
+        SearchError::HyperClientError(err)
+    }
+}
+
 impl fmt::Display for SearchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -417,6 +441,8 @@ impl fmt::Display for SearchError {
             SearchError::SurfError(ref e) => write!(f, "Surf Error: {e}"),
             #[cfg(feature = "aio_tokio")]
             SearchError::HyperError(ref e) => write!(f, "Hyper Error: {e}"),
+            #[cfg(feature = "aio_tokio")]
+            SearchError::HyperClientError(ref e) => write!(f, "Hyper Client Error: {e}"),
             #[cfg(feature = "aio_tokio")]
             SearchError::InvalidUri(ref e) => write!(f, "InvalidUri Error: {e}"),
         }
@@ -436,6 +462,8 @@ impl error::Error for SearchError {
             SearchError::SurfError(ref e) => Some(e.as_ref()),
             #[cfg(feature = "aio_tokio")]
             SearchError::HyperError(ref e) => Some(e),
+            #[cfg(feature = "aio_tokio")]
+            SearchError::HyperClientError(ref e) => Some(e),
             #[cfg(feature = "aio_tokio")]
             SearchError::InvalidUri(ref e) => Some(e),
         }
@@ -457,9 +485,7 @@ impl From<RequestError> for GetGenericPortMappingEntryError {
     fn from(err: RequestError) -> GetGenericPortMappingEntryError {
         match err {
             RequestError::ErrorCode(606, _) => GetGenericPortMappingEntryError::ActionNotAuthorized,
-            RequestError::ErrorCode(713, _) => {
-                GetGenericPortMappingEntryError::SpecifiedArrayIndexInvalid
-            }
+            RequestError::ErrorCode(713, _) => GetGenericPortMappingEntryError::SpecifiedArrayIndexInvalid,
             other => GetGenericPortMappingEntryError::RequestError(other),
         }
     }


### PR DESCRIPTION
This updates `hyper` and `http` to 1.0. Fixes #4.

The `common::parsing::test_parse_device2` test fails for me, but also seems to fail on master so I'm not sure what's up with that.