### PR TITLE
fix: correctly apply timeouts across implementations

### DIFF
--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -47,19 +47,29 @@ impl Provider for Tokio {
 
 /// Search for a gateway with the provided options.
 pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<Tokio>, SearchError> {
+    let search_timeout = options.timeout.unwrap_or(DEFAULT_TIMEOUT);
+    match timeout(search_timeout, search_gateway_inner(options)).await {
+        Ok(Ok(gateway)) => Ok(gateway),
+        Ok(Err(err)) => Err(err),
+        Err(_err) => {
+            // Timeout
+            Err(SearchError::NoResponseWithinTimeout)
+        }
+    }
+}
+
+async fn search_gateway_inner(options: SearchOptions) -> Result<Gateway<Tokio>, SearchError> {
     // Create socket for future calls
     let mut socket = UdpSocket::bind(&options.bind_addr).await?;
 
     send_search_request(&mut socket, options.broadcast_address).await?;
+    let response_timeout = options.single_search_timeout.unwrap_or(RESPONSE_TIMEOUT);
 
-    let max_search_time = options.timeout.unwrap_or(DEFAULT_TIMEOUT);
-    let start_search_time = std::time::Instant::now();
-
-    while start_search_time.elapsed() < max_search_time {
+    loop {
         let search_response = receive_search_response(&mut socket);
 
         // Receive search response
-        let (response_body, from) = match timeout(RESPONSE_TIMEOUT, search_response).await {
+        let (response_body, from) = match timeout(response_timeout, search_response).await {
             Ok(Ok(v)) => v,
             Ok(Err(err)) => {
                 debug!("error while receiving broadcast response: {err}");
@@ -104,8 +114,6 @@ pub async fn search_gateway(options: SearchOptions) -> Result<Gateway<Tokio>, Se
             provider: Tokio,
         });
     }
-
-    Err(SearchError::NoResponseWithinTimeout)
 }
 
 // Create a new search.

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -29,6 +29,8 @@ pub struct SearchOptions {
     pub broadcast_address: SocketAddr,
     /// Timeout for a search iteration (defaults to 10s)
     pub timeout: Option<Duration>,
+    /// Timeout for a single search response (defaults to 5s)
+    pub single_search_timeout: Option<Duration>,
 }
 
 impl Default for SearchOptions {
@@ -37,6 +39,7 @@ impl Default for SearchOptions {
             bind_addr: (IpAddr::from([0, 0, 0, 0]), 0).into(),
             broadcast_address: "239.255.255.250:1900".parse().unwrap(),
             timeout: Some(DEFAULT_TIMEOUT),
+            single_search_timeout: Some(RESPONSE_TIMEOUT),
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::net::{SocketAddr, UdpSocket};
 use std::str;
+use std::time::{Duration, Instant};
 
 use attohttpc::{Method, RequestBuilder};
 use log::debug;
 
+use crate::common::options::{DEFAULT_TIMEOUT, RESPONSE_TIMEOUT};
 use crate::common::{messages, parsing, SearchOptions};
 use crate::errors::SearchError;
 use crate::gateway::Gateway;
@@ -26,19 +28,27 @@ use crate::gateway::Gateway;
 /// }
 /// ```
 pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
+    let start = Instant::now();
+    let max_time = options.timeout.unwrap_or(DEFAULT_TIMEOUT);
+
     let socket = UdpSocket::bind(options.bind_addr)?;
-    socket.set_read_timeout(options.timeout)?;
+
+    let read_timeout = options.single_search_timeout.unwrap_or(RESPONSE_TIMEOUT);
+    socket.set_read_timeout(Some(read_timeout))?;
 
     socket.send_to(messages::SEARCH_REQUEST.as_bytes(), options.broadcast_address)?;
 
-    loop {
+    while start.elapsed() < max_time {
         let mut buf = [0u8; 1500];
+
+        // limit read, to the remaining time available
+        socket.set_read_timeout(Some(max_time - start.elapsed()))?;
         let (read, _) = socket.recv_from(&mut buf)?;
         let text = str::from_utf8(&buf[..read])?;
 
         let (addr, root_url) = parsing::parse_search_result(text)?;
 
-        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url) {
+        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url, max_time - start.elapsed()) {
             Ok(o) => o,
             Err(e) => {
                 debug!(
@@ -49,7 +59,7 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
             }
         };
 
-        let control_schema = match get_schemas(&addr, &control_schema_url) {
+        let control_schema = match get_schemas(&addr, &control_schema_url, max_time - start.elapsed()) {
             Ok(o) => o,
             Err(e) => {
                 debug!(
@@ -68,24 +78,30 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
             control_schema,
         });
     }
+
+    Err(SearchError::NoResponseWithinTimeout)
 }
 
-fn get_control_urls(addr: &SocketAddr, root_url: &str) -> Result<(String, String), SearchError> {
+fn get_control_urls(addr: &SocketAddr, root_url: &str, timeout: Duration) -> Result<(String, String), SearchError> {
     let url = format!("http://{}:{}{}", addr.ip(), addr.port(), root_url);
     match RequestBuilder::try_new(Method::GET, url) {
         Ok(request_builder) => {
-            let response = request_builder.send()?;
+            let response = request_builder.timeout(timeout).send()?;
             parsing::parse_control_urls(&response.bytes()?[..])
         }
         Err(error) => Err(SearchError::HttpError(error)),
     }
 }
 
-fn get_schemas(addr: &SocketAddr, control_schema_url: &str) -> Result<HashMap<String, Vec<String>>, SearchError> {
+fn get_schemas(
+    addr: &SocketAddr,
+    control_schema_url: &str,
+    timeout: Duration,
+) -> Result<HashMap<String, Vec<String>>, SearchError> {
     let url = format!("http://{}:{}{}", addr.ip(), addr.port(), control_schema_url);
     match RequestBuilder::try_new(Method::GET, url) {
         Ok(request_builder) => {
-            let response = request_builder.send()?;
+            let response = request_builder.timeout(timeout).send()?;
             parsing::parse_schemas(&response.bytes()?[..])
         }
         Err(error) => Err(SearchError::HttpError(error)),


### PR DESCRIPTION
These were broken in 0.15 unfortunately. 

I have added `single_search_timeout` to the options, to be able to control a single search, as well as applying the overall timeout consistently now. 

Ref https://github.com/n0-computer/iroh/issues/2876