### PR TITLE
refactor: remove async-trait and set rust version to 1.75

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 homepage = "https://github.com/dariusc93/rust-igd"
 keywords = ["igd", "upnp", "tokio", "async-std"]
 license = "MIT"
+rust-version = "1.75"
 name = "igd-next"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-igd"
@@ -27,7 +28,6 @@ http-body-util = { version = "0.1", optional = true }
 
 url = "2"
 xmltree = "0.10"
-async-trait = { version = "0.1.72", optional = true }
 
 [dependencies.hyper]
 default-features = false
@@ -47,8 +47,8 @@ tokio = { version = "1", features = ["full"] }
 async-std = { version = "1", features = ["attributes"]}
 
 [features]
-aio_tokio = ["futures", "tokio", "hyper", "hyper-util", "http-body-util", "bytes", "http", "async-trait"]
-aio_async_std = ["futures", "async-std", "surf/h1-client-rustls", "bytes", "http", "async-trait"]
+aio_tokio = ["futures", "tokio", "hyper", "hyper-util", "http-body-util", "bytes", "http"]
+aio_async_std = ["futures", "async-std", "surf/h1-client-rustls", "bytes", "http"]
 default = []
 
 [[example]]

--- a/src/aio/async_std.rs
+++ b/src/aio/async_std.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 
 use async_std::{future::timeout, net::UdpSocket};
-use async_trait::async_trait;
 use futures::prelude::*;
 use log::debug;
 
@@ -19,7 +18,6 @@ use crate::RequestError;
 #[derive(Debug, Clone)]
 pub struct AsyncStd;
 
-#[async_trait]
 impl Provider for AsyncStd {
     async fn send_async(url: &str, action: &str, body: &str) -> Result<String, RequestError> {
         Ok(surf::post(url)

--- a/src/aio/mod.rs
+++ b/src/aio/mod.rs
@@ -8,7 +8,7 @@ pub mod tokio;
 #[cfg(feature = "aio_async_std")]
 pub mod async_std;
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::RequestError;
 
@@ -18,8 +18,7 @@ pub(crate) const MAX_RESPONSE_SIZE: usize = 1500;
 pub(crate) const HEADER_NAME: &str = "SOAPAction";
 
 /// Trait to allow abstracting over `tokio` and `async-std`.
-#[async_trait]
 pub trait Provider {
     /// Send an async request over the executor.
-    async fn send_async(url: &str, action: &str, body: &str) -> Result<String, RequestError>;
+    fn send_async(url: &str, action: &str, body: &str) -> impl Future<Output = Result<String, RequestError>>;
 }

--- a/src/aio/mod.rs
+++ b/src/aio/mod.rs
@@ -20,5 +20,5 @@ pub(crate) const HEADER_NAME: &str = "SOAPAction";
 /// Trait to allow abstracting over `tokio` and `async-std`.
 pub trait Provider {
     /// Send an async request over the executor.
-    fn send_async(url: &str, action: &str, body: &str) -> impl Future<Output = Result<String, RequestError>>;
+    fn send_async(url: &str, action: &str, body: &str) -> impl Future<Output = Result<String, RequestError>> + Send;
 }

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -1,6 +1,5 @@
 //! Tokio abstraction for the aio [`Gateway`].
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use futures::prelude::*;
 use http_body_util::{BodyExt, Empty};
@@ -23,7 +22,6 @@ use log::debug;
 #[derive(Debug, Clone)]
 pub struct Tokio;
 
-#[async_trait]
 impl Provider for Tokio {
     async fn send_async(url: &str, action: &str, body: &str) -> Result<String, RequestError> {
         let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();


### PR DESCRIPTION
- removes async-trait, using RPIT instead.
- Set MSRV to 1.75

Note: 
- Due to setting the MSRV, this will effectively be a breaking change and would be merged for 0.17.0