### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ At the moment, you can search for the gateway, request the gateway's external ad
 
 Contributions are welcome! This is pretty delicate to test, please submit an issue if you have trouble using this.
 
-* [Documentation](https://docs.rs/igd/)
-* [Repository](https://github.com/sbstp/rust-igd)
-* [Crates.io](https://crates.io/crates/igd)
+* [Documentation](https://docs.rs/igd-next/)
+* [Repository](https://github.com/dariusc93/rust-igd)
+* [Crates.io](https://crates.io/crates/igd-next)
 
 ## License
 MIT


### PR DESCRIPTION
Hi, was looking for a UPnP rust crate and came across this fork. Glad to see you picked it up!

Was browsing on crates.io and got confused because the README still has the links to the original repo.
Thought I'd quickly fix it with this PR :)