### PR TITLE
chore: update rand to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
 http = { version = "1", optional = true }
 log = "0.4"
-rand = "0.9.0"
+rand = "0.10"
 tokio = { version = "1", optional = true, features = ["net"] }
 http-body-util = { version = "0.1", optional = true }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,7 +4,7 @@ pub mod parsing;
 
 pub use self::options::SearchOptions;
 
-use rand::{self, Rng};
+use rand::{self, RngExt};
 
 pub fn random_port() -> u16 {
     rand::rng().random_range(32_768_u16..65_535_u16)


### PR DESCRIPTION
Updates rand to version 0.10.

This is required for upstream dependencies of igd-next (noq, iroh) to avoid duplicate rand dependencies in the future.

Would appreciate a release with this! :)