### PR TITLE
chore: derive Hash for PortMappingProtocol

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod search;
 use std::fmt;
 
 /// Represents the protocols available for port mapping.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PortMappingProtocol {
     /// TCP protocol
     TCP,


### PR DESCRIPTION
Derives `Hash` for `PortMappingProtocol`, allowing it to be used as a key in `HashMap` and `HashSet`.
