### PR TITLE
refactor: Feature-gate attohttpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.17.1"
 all-features = true
 
 [dependencies]
-attohttpc = { version = "0.30.0", default-features = false }
+attohttpc = { version = "0.30.0", default-features = false, optional = true }
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
 http = { version = "1", optional = true }
@@ -44,17 +44,21 @@ simplelog = "0.12"
 tokio = { version = "1", features = ["full"] }
 
 [features]
+default = ["io_sync"]
+io_sync = ["attohttpc"]
 aio_tokio = ["futures", "tokio", "hyper", "hyper-util", "http-body-util", "bytes", "http"]
-default = []
 
 [[example]]
 name = "add_any_port"
+required-features = ["io_sync"]
 
 [[example]]
 name = "add_port"
+required-features = ["io_sync"]
 
 [[example]]
 name = "add_remove"
+required-features = ["io_sync"]
 
 [[example]]
 name = "aio_tokio"
@@ -62,6 +66,8 @@ required-features = ["aio_tokio"]
 
 [[example]]
 name = "external_ip"
+required-features = ["io_sync"]
 
 [[example]]
 name = "remove_port"
+required-features = ["io_sync"]

--- a/README.md
+++ b/README.md
@@ -9,5 +9,11 @@ Contributions are welcome! This is pretty delicate to test, please submit an iss
 * [Repository](https://github.com/dariusc93/rust-igd)
 * [Crates.io](https://crates.io/crates/igd-next)
 
+## Feature flags
+
+By default the crate uses synchronous IO, using [`attohttpc`](https://crates.io/crates/attohttpc/) as its HTTP client.
+The crate also ships an async implementation that uses `tokio` and `hyper`. To use it, disable `default-features` and 
+enable the `aio_tokio` feature.
+
 ## License
 MIT

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,10 +8,10 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "aio_tokio")]
 use tokio::time::error::Elapsed;
 
-
 /// Errors that can occur when sending the request to the gateway.
 #[derive(Debug)]
 pub enum RequestError {
+    #[cfg(feature = "io_sync")]
     /// attohttp error
     AttoHttpError(attohttpc::Error),
     /// IO Error
@@ -38,6 +38,7 @@ pub enum RequestError {
     Utf8Error(FromUtf8Error),
 }
 
+#[cfg(feature = "io_sync")]
 impl From<attohttpc::Error> for RequestError {
     fn from(err: attohttpc::Error) -> RequestError {
         RequestError::AttoHttpError(err)
@@ -88,6 +89,7 @@ impl From<hyper_util::client::legacy::Error> for RequestError {
 impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            #[cfg(feature = "io_sync")]
             RequestError::AttoHttpError(ref e) => write!(f, "HTTP error {e}"),
             RequestError::InvalidResponse(ref e) => write!(f, "Invalid response from gateway: {e}"),
             RequestError::IoError(ref e) => write!(f, "IO error. {e}"),
@@ -108,6 +110,7 @@ impl fmt::Display for RequestError {
 impl std::error::Error for RequestError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
+            #[cfg(feature = "io_sync")]
             RequestError::AttoHttpError(ref e) => Some(e),
             RequestError::InvalidResponse(..) => None,
             RequestError::IoError(ref e) => Some(e),
@@ -313,6 +316,7 @@ impl std::error::Error for AddPortError {
 #[derive(Debug)]
 pub enum SearchError {
     /// Http/Hyper error
+    #[cfg(feature = "io_sync")]
     HttpError(attohttpc::Error),
     /// Unable to process the response
     InvalidResponse,
@@ -335,6 +339,7 @@ pub enum SearchError {
     InvalidUri(hyper::http::uri::InvalidUri),
 }
 
+#[cfg(feature = "io_sync")]
 impl From<attohttpc::Error> for SearchError {
     fn from(err: attohttpc::Error) -> SearchError {
         SearchError::HttpError(err)
@@ -390,6 +395,7 @@ impl From<hyper_util::client::legacy::Error> for SearchError {
 impl fmt::Display for SearchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            #[cfg(feature = "io_sync")]
             SearchError::HttpError(ref e) => write!(f, "HTTP error {e}"),
             SearchError::InvalidResponse => write!(f, "Invalid response"),
             SearchError::NoResponseWithinTimeout => write!(f, "No response within timeout"),
@@ -409,6 +415,7 @@ impl fmt::Display for SearchError {
 impl error::Error for SearchError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
+            #[cfg(feature = "io_sync")]
             SearchError::HttpError(ref e) => Some(e),
             SearchError::InvalidResponse => None,
             SearchError::NoResponseWithinTimeout => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,23 +5,33 @@
 //! You can then communicate with the device via this object.
 
 // data structures
+#[cfg(any(feature = "io_sync", feature = "aio_tokio"))]
 pub use self::common::parsing::PortMappingEntry;
+#[cfg(any(feature = "io_sync", feature = "aio_tokio"))]
 pub use self::common::SearchOptions;
+#[cfg(any(feature = "io_sync", feature = "aio_tokio"))]
 pub use self::errors::{
     AddAnyPortError, AddPortError, GetExternalIpError, GetGenericPortMappingEntryError, RemovePortError, RequestError,
     SearchError,
 };
+#[cfg(any(feature = "io_sync", feature = "aio_tokio"))]
 pub use self::errors::{Error, Result};
+#[cfg(feature = "io_sync")]
 pub use self::gateway::Gateway;
 
 // search of gateway
+#[cfg(feature = "io_sync")]
 pub use self::search::search_gateway;
 
 #[cfg(feature = "aio_tokio")]
 pub mod aio;
+#[cfg(any(feature = "io_sync", feature = "aio_tokio"))]
 mod common;
+#[cfg(any(feature = "io_sync", feature = "aio_tokio"))]
 mod errors;
+#[cfg(feature = "io_sync")]
 mod gateway;
+#[cfg(feature = "io_sync")]
 mod search;
 
 use std::fmt;


### PR DESCRIPTION
This adds an enabled-by-default feature flag `io_sync`, and makes `attohttpc` an optional dependency behind this feature flag. This allows users who use the `aio_tokio` feature to not have to compile `attohttpc`, which will be unused anyway.

## Breaking changes

When using `igd_next` with `default-features = false` you now need to enable the `io_sync` feature to use the `Gateway` and `search_gateway` functions. When using the `aio_tokio` feature, it is now recommended to disable the  default features to not needlessly compile `attohttpc`.