### PR TITLE
fix: harden search and bound control requests

### DIFF
--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -12,7 +12,7 @@ use std::net::SocketAddr;
 use tokio::{net::UdpSocket, time::timeout};
 
 use super::{Provider, HEADER_NAME, MAX_RESPONSE_SIZE};
-use crate::common::options::{DEFAULT_TIMEOUT, RESPONSE_TIMEOUT};
+use crate::common::options::{DEFAULT_REQUEST_TIMEOUT, DEFAULT_TIMEOUT, RESPONSE_TIMEOUT};
 use crate::common::{messages, parsing, SearchOptions};
 use crate::errors::SearchError;
 use crate::{aio::Gateway, RequestError};
@@ -36,10 +36,14 @@ impl Provider for Tokio {
             .header(CONTENT_LENGTH, body.len() as u64)
             .body(body)?;
 
-        let resp = client.request(req).await?;
-        let body = resp.into_body().collect().await?.to_bytes();
-        let string = String::from_utf8(body.to_vec())?;
-        Ok(string)
+        let send = async {
+            let resp = client.request(req).await?;
+            let body = resp.into_body().collect().await?.to_bytes();
+            let string = String::from_utf8(body.to_vec())?;
+            Ok::<_, RequestError>(string)
+        };
+
+        timeout(DEFAULT_REQUEST_TIMEOUT, send).await?
     }
 }
 

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -6,6 +6,9 @@ pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Timeout for each broadcast response during a gateway search.
 #[allow(dead_code)]
 pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Default timeout for a control request to the gateway.
+#[allow(dead_code)]
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Gateway search configuration
 ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,7 +48,7 @@ pub enum RequestError {
 #[cfg(feature = "aio_tokio")]
 impl From<Elapsed> for RequestError {
     fn from(_err: Elapsed) -> RequestError {
-        RequestError::IoError(io::Error::new(io::ErrorKind::TimedOut, "timer failed"))
+        RequestError::IoError(io::Error::new(io::ErrorKind::TimedOut, "control request timed out"))
     }
 }
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
 
+use crate::common::options::DEFAULT_REQUEST_TIMEOUT;
 use crate::common::{self, messages, parsing, parsing::RequestResult};
 use crate::errors::{self, AddAnyPortError, AddPortError, GetExternalIpError, RemovePortError, RequestError};
 use crate::PortMappingProtocol;
@@ -30,6 +31,7 @@ impl Gateway {
 
         let response = match RequestBuilder::try_new(Method::POST, url) {
             Ok(request_builder) => request_builder
+                .timeout(DEFAULT_REQUEST_TIMEOUT)
                 .header("SOAPAction", header)
                 .header("Content-Type", "text/xml")
                 .text(body)
@@ -126,8 +128,10 @@ impl Gateway {
         const ATTEMPTS: usize = 20;
 
         for _ in 0..ATTEMPTS {
-            if let Ok(port) = self.add_random_port_mapping(protocol, local_addr, lease_duration, description) {
-                return Ok(port);
+            match self.add_random_port_mapping(protocol, local_addr, lease_duration, description) {
+                Ok(port) => return Ok(port),
+                Err(AddAnyPortError::NoPortsAvailable) => continue,
+                Err(e) => return Err(e),
             }
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -33,33 +33,57 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
 
     let socket = UdpSocket::bind(options.bind_addr)?;
 
-    let read_timeout = options.single_search_timeout.unwrap_or(RESPONSE_TIMEOUT);
-    socket.set_read_timeout(Some(read_timeout))?;
+    let response_timeout = options.single_search_timeout.unwrap_or(RESPONSE_TIMEOUT);
 
     socket.send_to(messages::SEARCH_REQUEST.as_bytes(), options.broadcast_address)?;
 
     while start.elapsed() < max_time {
-        let mut buf = [0u8; 1500];
+        let remaining = max_time.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            break;
+        }
 
         // limit read, to the remaining time available
-        socket.set_read_timeout(Some(max_time - start.elapsed()))?;
-        let (read, _) = socket.recv_from(&mut buf)?;
-        let text = str::from_utf8(&buf[..read])?;
+        socket.set_read_timeout(Some(response_timeout.min(remaining)))?;
 
-        let (addr, root_url) = parsing::parse_search_result(text)?;
-
-        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url, max_time - start.elapsed()) {
-            Ok(o) => o,
+        let mut buf = [0u8; 1500];
+        let (read, _) = match socket.recv_from(&mut buf) {
+            Ok(v) => v,
             Err(e) => {
-                debug!(
-                    "Error has occurred while getting control urls. error: {}, addr: {}, root_url: {}",
-                    e, addr, root_url
-                );
+                debug!("error while receiving broadcast response: {e}");
                 continue;
             }
         };
 
-        let control_schema = match get_schemas(&addr, &control_schema_url, max_time - start.elapsed()) {
+        let text = match str::from_utf8(&buf[..read]) {
+            Ok(text) => text,
+            Err(e) => {
+                debug!("received a non-utf8 broadcast response: {e}");
+                continue;
+            }
+        };
+
+        let (addr, root_url) = match parsing::parse_search_result(text) {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("could not parse broadcast response: {e}");
+                continue;
+            }
+        };
+
+        let (control_schema_url, control_url) =
+            match get_control_urls(&addr, &root_url, max_time.saturating_sub(start.elapsed())) {
+                Ok(o) => o,
+                Err(e) => {
+                    debug!(
+                        "Error has occurred while getting control urls. error: {}, addr: {}, root_url: {}",
+                        e, addr, root_url
+                    );
+                    continue;
+                }
+            };
+
+        let control_schema = match get_schemas(&addr, &control_schema_url, max_time.saturating_sub(start.elapsed())) {
             Ok(o) => o,
             Err(e) => {
                 debug!(


### PR DESCRIPTION
- Added default timeout for request (noticed some gateways may take a long time to respond, if ever)
- Bring synchronous code to parity with the async implementation
- Remove potential panics by using `saturating_sub` for the remaining time