### PR TITLE
refactor: use the discovered service type for SOAP requests

### DIFF
--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -22,14 +22,18 @@ pub struct Gateway<P> {
     pub control_schema_url: String,
     /// Control schema for all actions
     pub control_schema: HashMap<String, Vec<String>>,
+    /// Service type of the gateway's WAN connection service (e.g.
+    /// `urn:schemas-upnp-org:service:WANIPConnection:1`)
+    pub service_type: String,
     /// Executor provider
     pub provider: P,
 }
 
 impl<P: Provider> Gateway<P> {
-    async fn perform_request(&self, header: &str, body: &str, ok: &str) -> Result<RequestReponse, RequestError> {
+    async fn perform_request(&self, action: &str, body: &str, ok: &str) -> Result<RequestReponse, RequestError> {
         let url = format!("{self}");
-        let text = P::send_async(&url, header, body).await?;
+        let header = messages::soap_action(&self.service_type, action);
+        let text = P::send_async(&url, &header, body).await?;
         parsing::parse_response(text, ok)
     }
 
@@ -37,8 +41,8 @@ impl<P: Provider> Gateway<P> {
     pub async fn get_external_ip(&self) -> Result<IpAddr, GetExternalIpError> {
         let result = self
             .perform_request(
-                messages::GET_EXTERNAL_IP_HEADER,
-                &messages::format_get_external_ip_message(),
+                messages::GET_EXTERNAL_IP_ACTION,
+                &messages::format_get_external_ip_message(&self.service_type),
                 "GetExternalIPAddressResponse",
             )
             .await;
@@ -102,8 +106,9 @@ impl<P: Provider> Gateway<P> {
 
             let resp = self
                 .perform_request(
-                    messages::ADD_ANY_PORT_MAPPING_HEADER,
+                    messages::ADD_ANY_PORT_MAPPING_ACTION,
                     &messages::format_add_any_port_mapping_message(
+                        &self.service_type,
                         schema,
                         protocol,
                         external_port,
@@ -193,8 +198,9 @@ impl<P: Provider> Gateway<P> {
         description: &str,
     ) -> Result<(), RequestError> {
         self.perform_request(
-            messages::ADD_PORT_MAPPING_HEADER,
+            messages::ADD_PORT_MAPPING_ACTION,
             &messages::format_add_port_mapping_message(
+                &self.service_type,
                 self.control_schema
                     .get("AddPortMapping")
                     .ok_or_else(|| RequestError::UnsupportedAction("AddPortMapping".to_string()))?,
@@ -242,8 +248,9 @@ impl<P: Provider> Gateway<P> {
     pub async fn remove_port(&self, protocol: PortMappingProtocol, external_port: u16) -> Result<(), RemovePortError> {
         let res = self
             .perform_request(
-                messages::DELETE_PORT_MAPPING_HEADER,
+                messages::DELETE_PORT_MAPPING_ACTION,
                 &messages::format_delete_port_message(
+                    &self.service_type,
                     self.control_schema.get("DeletePortMapping").ok_or_else(|| {
                         RemovePortError::RequestError(RequestError::UnsupportedAction("DeletePortMapping".to_string()))
                     })?,
@@ -267,8 +274,8 @@ impl<P: Provider> Gateway<P> {
     ) -> Result<parsing::PortMappingEntry, errors::GetGenericPortMappingEntryError> {
         let result = self
             .perform_request(
-                messages::GET_GENERIC_PORT_MAPPING_ENTRY,
-                &messages::formate_get_generic_port_mapping_entry_message(index),
+                messages::GET_GENERIC_PORT_MAPPING_ENTRY_ACTION,
+                &messages::formate_get_generic_port_mapping_entry_message(&self.service_type, index),
                 "GetGenericPortMappingEntryResponse",
             )
             .await;

--- a/src/aio/tokio.rs
+++ b/src/aio/tokio.rs
@@ -87,7 +87,7 @@ async fn search_gateway_inner(options: SearchOptions) -> Result<Gateway<Tokio>, 
             }
         };
 
-        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url).await {
+        let (service_type, control_schema_url, control_url) = match get_control_urls(&addr, &root_url).await {
             Ok(v) => v,
             Err(e) => {
                 debug!("error getting control URLs: {}", e);
@@ -109,6 +109,7 @@ async fn search_gateway_inner(options: SearchOptions) -> Result<Gateway<Tokio>, 
             control_url,
             control_schema_url,
             control_schema,
+            service_type,
             provider: Tokio,
         });
     }
@@ -148,7 +149,7 @@ fn handle_broadcast_resp(from: &SocketAddr, data: &[u8]) -> Result<(SocketAddr, 
     Ok((addr, root_url))
 }
 
-async fn get_control_urls(addr: &SocketAddr, path: &str) -> Result<(String, String), SearchError> {
+async fn get_control_urls(addr: &SocketAddr, path: &str) -> Result<(String, String, String), SearchError> {
     let uri = match format!("http://{addr}{path}").parse() {
         Ok(uri) => uri,
         Err(err) => return Err(SearchError::from(err)),

--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -8,16 +8,21 @@ ST:urn:schemas-upnp-org:device:InternetGatewayDevice:1\r
 Man:\"ssdp:discover\"\r
 MX:3\r\n\r\n";
 
-pub const GET_EXTERNAL_IP_HEADER: &str = r#""urn:schemas-upnp-org:service:WANIPConnection:1#GetExternalIPAddress""#;
+// SOAP action names.
+pub const GET_EXTERNAL_IP_ACTION: &str = "GetExternalIPAddress";
 
-pub const ADD_ANY_PORT_MAPPING_HEADER: &str = r#""urn:schemas-upnp-org:service:WANIPConnection:1#AddAnyPortMapping""#;
+pub const ADD_ANY_PORT_MAPPING_ACTION: &str = "AddAnyPortMapping";
 
-pub const ADD_PORT_MAPPING_HEADER: &str = r#""urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping""#;
+pub const ADD_PORT_MAPPING_ACTION: &str = "AddPortMapping";
 
-pub const DELETE_PORT_MAPPING_HEADER: &str = r#""urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping""#;
+pub const DELETE_PORT_MAPPING_ACTION: &str = "DeletePortMapping";
 
-pub const GET_GENERIC_PORT_MAPPING_ENTRY: &str =
-    r#""urn:schemas-upnp-org:service:WANIPConnection:1#GetGenericPortMappingEntry""#;
+pub const GET_GENERIC_PORT_MAPPING_ENTRY_ACTION: &str = "GetGenericPortMappingEntry";
+
+/// Build the quoted `SOAPAction` header value (`"<service_type>#<action>"`) for a request.
+pub fn soap_action(service_type: &str, action: &str) -> String {
+    format!("\"{service_type}#{action}\"")
+}
 
 const MESSAGE_HEAD: &str = r#"<?xml version="1.0"?>
 <s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
@@ -30,18 +35,15 @@ fn format_message(body: String) -> String {
     format!("{MESSAGE_HEAD}{body}{MESSAGE_TAIL}")
 }
 
-pub fn format_get_external_ip_message() -> String {
-    r#"<?xml version="1.0"?>
-<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
-    <s:Body>
-        <m:GetExternalIPAddress xmlns:m="urn:schemas-upnp-org:service:WANIPConnection:1">
-        </m:GetExternalIPAddress>
-    </s:Body>
-</s:Envelope>"#
-    .into()
+pub fn format_get_external_ip_message(service_type: &str) -> String {
+    format_message(format!(
+        r#"<m:GetExternalIPAddress xmlns:m="{service_type}">
+        </m:GetExternalIPAddress>"#
+    ))
 }
 
 pub fn format_add_any_port_mapping_message(
+    service_type: &str,
     schema: &[String],
     protocol: PortMappingProtocol,
     external_port: u16,
@@ -72,13 +74,14 @@ pub fn format_add_any_port_mapping_message(
         .join("\n");
 
     format_message(format!(
-        r#"<u:AddAnyPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
+        r#"<u:AddAnyPortMapping xmlns:u="{service_type}">
         {args}
         </u:AddAnyPortMapping>"#,
     ))
 }
 
 pub fn format_add_port_mapping_message(
+    service_type: &str,
     schema: &[String],
     protocol: PortMappingProtocol,
     external_port: u16,
@@ -109,13 +112,18 @@ pub fn format_add_port_mapping_message(
         .join("\n");
 
     format_message(format!(
-        r#"<u:AddPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
+        r#"<u:AddPortMapping xmlns:u="{service_type}">
         {args}
         </u:AddPortMapping>"#
     ))
 }
 
-pub fn format_delete_port_message(schema: &[String], protocol: PortMappingProtocol, external_port: u16) -> String {
+pub fn format_delete_port_message(
+    service_type: &str,
+    schema: &[String],
+    protocol: PortMappingProtocol,
+    external_port: u16,
+) -> String {
     let args = schema
         .iter()
         .filter_map(|argument| {
@@ -134,16 +142,47 @@ pub fn format_delete_port_message(schema: &[String], protocol: PortMappingProtoc
         .join("\n");
 
     format_message(format!(
-        r#"<u:DeletePortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
+        r#"<u:DeletePortMapping xmlns:u="{service_type}">
         {args}
         </u:DeletePortMapping>"#
     ))
 }
 
-pub fn formate_get_generic_port_mapping_entry_message(port_mapping_index: u32) -> String {
+pub fn formate_get_generic_port_mapping_entry_message(service_type: &str, port_mapping_index: u32) -> String {
     format_message(format!(
-        r#"<u:GetGenericPortMappingEntry xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
+        r#"<u:GetGenericPortMappingEntry xmlns:u="{service_type}">
         <NewPortMappingIndex>{port_mapping_index}</NewPortMappingIndex>
         </u:GetGenericPortMappingEntry>"#
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PPP: &str = "urn:schemas-upnp-org:service:WANPPPConnection:1";
+
+    #[test]
+    fn soap_action_uses_service_type() {
+        assert_eq!(
+            soap_action(PPP, "AddPortMapping"),
+            "\"urn:schemas-upnp-org:service:WANPPPConnection:1#AddPortMapping\""
+        );
+    }
+
+    #[test]
+    fn message_body_uses_service_type() {
+        let body = format_add_port_mapping_message(
+            PPP,
+            &["NewProtocol".to_string(), "NewExternalPort".to_string()],
+            PortMappingProtocol::TCP,
+            12345,
+            "192.168.1.5:80".parse().unwrap(),
+            0,
+            "test",
+        );
+        assert!(body.contains(r#"xmlns:u="urn:schemas-upnp-org:service:WANPPPConnection:1""#));
+        assert!(body.contains("<NewProtocol>TCP</NewProtocol>"));
+        assert!(body.contains("<NewExternalPort>12345</NewExternalPort>"));
+    }
 }

--- a/src/common/parsing.rs
+++ b/src/common/parsing.rs
@@ -34,7 +34,9 @@ pub fn parse_search_result(text: &str) -> Result<(SocketAddr, String), SearchErr
     Err(InvalidResponse)
 }
 
-pub fn parse_control_urls<R>(resp: R) -> Result<(String, String), SearchError>
+/// Parse the device description, returning `(service_type, control_schema_url, control_url)`
+/// for the first supported WAN connection service found.
+pub fn parse_control_urls<R>(resp: R) -> Result<(String, String, String), SearchError>
 where
     R: io::Read,
 {
@@ -52,7 +54,7 @@ where
     urls.next().ok_or(SearchError::InvalidResponse)
 }
 
-fn parse_device(device: &Element) -> Option<(String, String)> {
+fn parse_device(device: &Element) -> Option<(String, String, String)> {
     let services = device.get_child("serviceList").and_then(|service_list| {
         service_list
             .children
@@ -71,7 +73,7 @@ fn parse_device(device: &Element) -> Option<(String, String)> {
     services.or(devices)
 }
 
-fn parse_device_list(device_list: &Element) -> Option<(String, String)> {
+fn parse_device_list(device_list: &Element) -> Option<(String, String, String)> {
     device_list
         .children
         .iter()
@@ -86,7 +88,7 @@ fn parse_device_list(device_list: &Element) -> Option<(String, String)> {
         .next()
 }
 
-fn parse_service(service: &Element) -> Option<(String, String)> {
+fn parse_service(service: &Element) -> Option<(String, String, String)> {
     let service_type = service.get_child("serviceType")?;
     let service_type = service_type
         .get_text()
@@ -103,6 +105,7 @@ fn parse_service(service: &Element) -> Option<(String, String)> {
         let control_url = service.get_child("controlURL");
         if let (Some(scpd_url), Some(control_url)) = (scpd_url, control_url) {
             Some((
+                service_type,
                 scpd_url.get_text().map(|s| s.into_owned()).unwrap_or_else(|| "".into()),
                 control_url
                     .get_text()
@@ -494,7 +497,8 @@ fn test_parse_device1() {
    </device>
 </root>"#;
 
-    let (control_schema_url, control_url) = parse_control_urls(text.as_bytes()).unwrap();
+    let (service_type, control_schema_url, control_url) = parse_control_urls(text.as_bytes()).unwrap();
+    assert_eq!(service_type, "urn:schemas-upnp-org:service:WANIPConnection:1");
     assert_eq!(control_url, "/ctl/IPConn");
     assert_eq!(control_schema_url, "/WANIPCn.xml");
 }
@@ -601,7 +605,8 @@ fn test_parse_device2() {
     "#;
     let result = parse_control_urls(text.as_bytes());
     assert!(result.is_ok());
-    let (control_schema_url, control_url) = result.unwrap();
+    let (service_type, control_schema_url, control_url) = result.unwrap();
+    assert_eq!(service_type, "urn:schemas-upnp-org:service:WANIPConnection:1");
     assert_eq!(control_url, "/igdupnp/control/WANIPConn1");
     assert_eq!(control_schema_url, "/igdconnSCPD.xml");
 }
@@ -688,7 +693,43 @@ fn test_parse_device3() {
 </device>
 </root>"#;
 
-    let (control_schema_url, control_url) = parse_control_urls(text.as_bytes()).unwrap();
+    let (service_type, control_schema_url, control_url) = parse_control_urls(text.as_bytes()).unwrap();
+    assert_eq!(service_type, "urn:schemas-upnp-org:service:WANIPConnection:1");
     assert_eq!(control_url, "/upnp/control/WANIPConn1");
     assert_eq!(control_schema_url, "/332b484d/wanipconnSCPD.xml");
+}
+
+#[test]
+fn test_parse_device_pppconnection() {
+    // A DSL/PPP gateway that only exposes WANPPPConnection:1 (not WANIPConnection).
+    let text = r#"<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+   <device>
+      <deviceType>urn:schemas-upnp-org:device:InternetGatewayDevice:1</deviceType>
+      <deviceList>
+         <device>
+            <deviceType>urn:schemas-upnp-org:device:WANDevice:1</deviceType>
+            <deviceList>
+               <device>
+                  <deviceType>urn:schemas-upnp-org:device:WANConnectionDevice:1</deviceType>
+                  <serviceList>
+                     <service>
+                        <serviceType>urn:schemas-upnp-org:service:WANPPPConnection:1</serviceType>
+                        <serviceId>urn:upnp-org:serviceId:WANPPPConn1</serviceId>
+                        <controlURL>/ctl/PPPConn</controlURL>
+                        <eventSubURL>/evt/PPPConn</eventSubURL>
+                        <SCPDURL>/WANPPPCn.xml</SCPDURL>
+                     </service>
+                  </serviceList>
+               </device>
+            </deviceList>
+         </device>
+      </deviceList>
+   </device>
+</root>"#;
+
+    let (service_type, control_schema_url, control_url) = parse_control_urls(text.as_bytes()).unwrap();
+    assert_eq!(service_type, "urn:schemas-upnp-org:service:WANPPPConnection:1");
+    assert_eq!(control_url, "/ctl/PPPConn");
+    assert_eq!(control_schema_url, "/WANPPPCn.xml");
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -21,15 +21,19 @@ pub struct Gateway {
     pub control_schema_url: String,
     /// Control schema for all actions
     pub control_schema: HashMap<String, Vec<String>>,
+    /// Service type of the gateway's WAN connection service (e.g.
+    /// `urn:schemas-upnp-org:service:WANIPConnection:1`)
+    pub service_type: String,
 }
 
 impl Gateway {
-    fn perform_request(&self, header: &str, body: &str, ok: &str) -> RequestResult {
+    fn perform_request(&self, action: &str, body: &str, ok: &str) -> RequestResult {
         let url = format!("http://{}{}", self.addr, self.control_url);
+        let header = messages::soap_action(&self.service_type, action);
 
         let response = match RequestBuilder::try_new(Method::POST, url) {
             Ok(request_builder) => request_builder
-                .header("SOAPAction", header)
+                .header("SOAPAction", header.as_str())
                 .header("Content-Type", "text/xml")
                 .text(body)
                 .send()?,
@@ -42,8 +46,8 @@ impl Gateway {
     /// Get the external IP address of the gateway.
     pub fn get_external_ip(&self) -> Result<IpAddr, GetExternalIpError> {
         parsing::parse_get_external_ip_response(self.perform_request(
-            messages::GET_EXTERNAL_IP_HEADER,
-            &messages::format_get_external_ip_message(),
+            messages::GET_EXTERNAL_IP_ACTION,
+            &messages::format_get_external_ip_message(&self.service_type),
             "GetExternalIPAddressResponse",
         ))
     }
@@ -99,8 +103,9 @@ impl Gateway {
             let external_port = common::random_port();
 
             parsing::parse_add_any_port_mapping_response(self.perform_request(
-                messages::ADD_ANY_PORT_MAPPING_HEADER,
+                messages::ADD_ANY_PORT_MAPPING_ACTION,
                 &messages::format_add_any_port_mapping_message(
+                    &self.service_type,
                     schema,
                     protocol,
                     external_port,
@@ -174,8 +179,9 @@ impl Gateway {
         description: &str,
     ) -> Result<(), RequestError> {
         self.perform_request(
-            messages::ADD_PORT_MAPPING_HEADER,
+            messages::ADD_PORT_MAPPING_ACTION,
             &messages::format_add_port_mapping_message(
+                &self.service_type,
                 self.control_schema
                     .get("AddPortMapping")
                     .ok_or_else(|| RequestError::UnsupportedAction("AddPortMapping".to_string()))?,
@@ -217,8 +223,9 @@ impl Gateway {
     /// Remove a port mapping.
     pub fn remove_port(&self, protocol: PortMappingProtocol, external_port: u16) -> Result<(), RemovePortError> {
         parsing::parse_delete_port_mapping_response(self.perform_request(
-            messages::DELETE_PORT_MAPPING_HEADER,
+            messages::DELETE_PORT_MAPPING_ACTION,
             &messages::format_delete_port_message(
+                &self.service_type,
                 self.control_schema.get("DeletePortMapping").ok_or_else(|| {
                     RemovePortError::RequestError(RequestError::UnsupportedAction("DeletePortMapping".to_string()))
                 })?,
@@ -239,8 +246,8 @@ impl Gateway {
         index: u32,
     ) -> Result<parsing::PortMappingEntry, errors::GetGenericPortMappingEntryError> {
         parsing::parse_get_generic_port_mapping_entry(self.perform_request(
-            messages::GET_GENERIC_PORT_MAPPING_ENTRY,
-            &messages::formate_get_generic_port_mapping_entry_message(index),
+            messages::GET_GENERIC_PORT_MAPPING_ENTRY_ACTION,
+            &messages::formate_get_generic_port_mapping_entry_message(&self.service_type, index),
             "GetGenericPortMappingEntryResponse",
         ))
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -48,16 +48,17 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
 
         let (addr, root_url) = parsing::parse_search_result(text)?;
 
-        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url, max_time - start.elapsed()) {
-            Ok(o) => o,
-            Err(e) => {
-                debug!(
-                    "Error has occurred while getting control urls. error: {}, addr: {}, root_url: {}",
-                    e, addr, root_url
-                );
-                continue;
-            }
-        };
+        let (service_type, control_schema_url, control_url) =
+            match get_control_urls(&addr, &root_url, max_time - start.elapsed()) {
+                Ok(o) => o,
+                Err(e) => {
+                    debug!(
+                        "Error has occurred while getting control urls. error: {}, addr: {}, root_url: {}",
+                        e, addr, root_url
+                    );
+                    continue;
+                }
+            };
 
         let control_schema = match get_schemas(&addr, &control_schema_url, max_time - start.elapsed()) {
             Ok(o) => o,
@@ -76,13 +77,18 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
             control_url,
             control_schema_url,
             control_schema,
+            service_type,
         });
     }
 
     Err(SearchError::NoResponseWithinTimeout)
 }
 
-fn get_control_urls(addr: &SocketAddr, root_url: &str, timeout: Duration) -> Result<(String, String), SearchError> {
+fn get_control_urls(
+    addr: &SocketAddr,
+    root_url: &str,
+    timeout: Duration,
+) -> Result<(String, String, String), SearchError> {
     let url = format!("http://{}:{}{}", addr.ip(), addr.port(), root_url);
     match RequestBuilder::try_new(Method::GET, url) {
         Ok(request_builder) => {


### PR DESCRIPTION
Every soap action header and request previously hardcoded the `WANIPConnection:1` namespace, even though the discovery also accepts `WANPPPConnection:1` and `WANIPConnection:2`. Devices exposing only `WANIPConnection:2` or `WANPPPConnection:1` were sent the wrong namespace and rejected the requests. 

This PR changes it so we capture the service type during discovery, store it as part of the gateway, and build the header `SOAPAction` and body namespace from it. 

Note:
- This adds `service_type` to `Gateway`, which is a breaking change. 